### PR TITLE
Move BACKUP_DIR to /tmp

### DIFF
--- a/src/backup.h
+++ b/src/backup.h
@@ -13,7 +13,7 @@
 #define _EASYCWMP_BACKUP_H__
 
 #include <microxml.h>
-#define BACKUP_DIR "/etc/easycwmp"
+#define BACKUP_DIR "/tmp/easycwmp"
 #define BACKUP_FILE BACKUP_DIR"/.backup.xml"
 
 int backup_extract_transfer_complete( mxml_node_t *node, char **msg_out, int *method_id);


### PR DESCRIPTION
BACKUP_DIR doesn't contain configuration files but runtime data and thus
should live in /tmp.