### PR TITLE
Do not exit after a successful download, remove redundant FREE() calls

### DIFF
--- a/src/cwmp.c
+++ b/src/cwmp.c
@@ -481,7 +481,6 @@ void cwmp_download_launch(struct uloop_timeout *timeout)
 		code = FAULT_9002;
 		goto end_fault;
 	}
-	if (status[0] == '1') exit(EXIT_SUCCESS);
 	goto out;
 
 end_fault :

--- a/src/xml.c
+++ b/src/xml.c
@@ -1411,8 +1411,6 @@ static int xml_handle_download(mxml_node_t *body_in,
 	cwmp_add_download(command_key, delay, file_size, download_url, file_type, username, password, n);
 	FREE(file_type);
 	FREE(command_key);
-	FREE(username);
-	FREE(password);
 
 	t = mxmlNewElement(body_out, "cwmp:DownloadResponse");
 	if (!t) return -1;
@@ -1444,8 +1442,6 @@ fault_out:
 	xml_create_generic_fault_message(body_out, code);
 	FREE(file_type);
 	FREE(command_key);
-	FREE(username);
-	FREE(password);
 	return 0;
 }
 


### PR DESCRIPTION
Addresses http://support.easycwmp.org/view.php?id=293.